### PR TITLE
[WIP] Capture a reference to the root span

### DIFF
--- a/propagation_test.go
+++ b/propagation_test.go
@@ -72,6 +72,7 @@ func TestSpanPropagator(t *testing.T) {
 	spans := make([]*Span, len(otSpans))
 	for i, s := range otSpans {
 		spans[i] = s.(*Span)
+		spans[i].context.firstInProcessContext = nil // This is not propagated by Inject/Extract
 	}
 
 	closer.Close()

--- a/span.go
+++ b/span.go
@@ -308,12 +308,19 @@ func setSamplingPriority(s *Span, value interface{}) bool {
 	}
 	s.Lock()
 	defer s.Unlock()
+	ctx := s.context.firstInProcessContext
+	if ctx == nil {
+		ctx = &s.context
+	}
+
 	if val == 0 {
-		s.context.flags = s.context.flags & (^flagSampled)
+		ctx.flags = ctx.flags & (^flagSampled)
+		s.context.flags = ctx.flags
 		return true
 	}
 	if s.tracer.isDebugAllowed(s.operationName) {
-		s.context.flags = s.context.flags | flagDebug | flagSampled
+		ctx.flags = ctx.flags | flagDebug | flagSampled
+		s.context.flags = ctx.flags
 		return true
 	}
 	return false

--- a/tracer.go
+++ b/tracer.go
@@ -299,6 +299,13 @@ func (t *Tracer) startSpanWithOptions(
 					ctx.baggage[k] = v
 				}
 			}
+
+			// copy root span context
+			if parent.firstInProcessContext == nil {
+				ctx.firstInProcessContext = &parent
+			} else {
+				ctx.firstInProcessContext = parent.firstInProcessContext
+			}
 		}
 	}
 


### PR DESCRIPTION
## Short description of the changes
- Quick and dirty stab at a method to capture and propagate the first in process span so that tags set in child spans can influence sampling decisions on other children
- TODO: reason about concurrent writes to root span flags
